### PR TITLE
Update README instructions to use 'docker-compose up' only

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ ToolServer is where XAgent's action takes place. It is a docker container that p
 So you should install `docker` and `docker-compose` first. 
 After that, you should build the docker image for ToolServer and start the docker container.
 ```bash
-docker-compose build
 docker-compose up
 ```
 Refer [here](ToolServer/README.md) for detailed information about our ToolServer.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -60,7 +60,6 @@ XAgent由三部分组成：
 因此，您应该首先安装`docker`和`docker-compose`。
 然后，您需要构建工具服务器的镜像。在`ToolServer`目录下，运行以下命令：
 ```bash
-cd ToolServer
 docker-compose up
 ```
 这将构建工具服务器的镜像并启动工具服务器的容器。如果您想在后台运行容器，请使用`docker-compose up -d`。


### PR DESCRIPTION
- Modified README.md to recommend using '--build' option with 'docker-compose up'
- Updated README_ZH.md to align with the English version

### 🤔 What is the nature of this change? / 这个变动的性质是？

- [x] Website, documentation, demo improvements / 网站、文档、Demo 改进


### 💡 Background or solution / 需求背景和解决方案
1. There is no need for using `docker-compose build` in README.md because this command 
> Builds, (re)creates, starts, and attaches to containers for a service.
> Unless they are already running, this command also starts any linked services.

2. There is no need or even confused to use `cd ToolServer` in README_ZH.md because `docker-compose.yml` is in root dir.