### PR TITLE
fix: upload file endless loop

### DIFF
--- a/XAgentWeb/src/views/playground/components/FileUpload.vue
+++ b/XAgentWeb/src/views/playground/components/FileUpload.vue
@@ -83,7 +83,9 @@ watch(() => fileList.value, (newVal) => {
         message: `The  file "${tipFileName}" type is not supported`
     });
   }
-  fileList.value = allowList
+  if (allowList.length !== fileList.value.length) {
+    fileList.value = allowList
+  }
 });
 
 const configStore = useConfigStore()


### PR DESCRIPTION
<!-- 
First of all, thank you for your contribution! 😄
首先，感谢你的贡献！😄
-->

### 🤔 What is the nature of this change? / 这个变动的性质是？

- [ ] New feature / 新特性提交
- [x] Fix bug / bug 修复
- [ ] Style optimization / 样式优化
- [ ] Performance optimization / 性能优化
- [ ] Code style optimization / 代码风格优化
- [ ] Build optimization / 构建优化
- [ ] Website, documentation, demo improvements / 网站、文档、Demo 改进
- [ ] Refactor code or style / 重构代码或样式
- [ ] Test related / 测试相关
- [ ] Other / 其他

### 🔗 Related Issue / 相关 Issue

close[#144](https://github.com/OpenBMB/XAgent/issues/144)

### 💡 Background or solution / 需求背景和解决方案

(The specific problem solved. / 解决的具体问题。)
gui界面选择文件上传的时候会卡住，应该是watch文件列表 过滤文件类型时因为重新赋值导致陷入死循环

### 📝 Changelog / 更新日志

(Describe changes from the user side, and list all potential break changes or other risks. / 从用户角度描述具体变化，以及可能的 breaking change 和其他风险。)
