### PR TITLE
Build optimization: this will configure to use the more secure SHA-256 based passw…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,5 @@ python-multipart
 apscheduler
 pinecone-client
 websockets
+
 cryptography


### PR DESCRIPTION
…ord authentication used in MySQL 8+ instead of the insecure mysql_native_password plugin.

To use caching_sha2_password with docker compose, you need to do the following steps:

1,Open your docker-compose.yml file and locate the service definition for your MySQL server. Add or modify the following line under the command key:

command: mysqld --default-authentication-plugin=caching_sha2_password

2,Restart your MySQL server container to apply the changes.

3,Connect to your MySQL server using the root account and execute the following SQL command to change the authentication plugin for the root user:

ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'xagent';