### PR TITLE
refactor: Improve argument parsing

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,74 +1,91 @@
 import os
-import sys
+from contextlib import redirect_stdout
 import argparse
 from copy import deepcopy
-from XAgent.config import CONFIG,ARGS
-from command import CommandLine,CommandLineParam
+from XAgent.config import CONFIG, ARGS
+from command import CommandLine, CommandLineParam
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """
-    Parse command line arguments
+    Parse the command line arguments and return them as an argparse.Namespace object.
 
     Returns:
-        argparse.Namespace: Object containing command line arguments.
+        argparse.Namespace: An object containing command line arguments and their values.
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--task", type=str,
-                        help="task description",required=True)
-    parser.add_argument("--upload_files", nargs='+',
-                        help="upload files")
-    parser.add_argument("--model", type=str,)
-    parser.add_argument("--record_dir", type=str,)
-    parser.add_argument("--mode", type=str, default="auto",
-                        help="mode, only support auto and manual, if you choose manual, you need to press enter to continue in each step")
-    parser.add_argument("--quiet", action="store_true",default=False)
+    parser.add_argument("--task", type=str, required=True, help="The task description.")
+    parser.add_argument("--upload-files", nargs='+', dest="upload_files", help="List of files to upload.")
+    parser.add_argument("--model", type=str, help="Model identifier for the task.")
+    parser.add_argument("--record-dir", type=str, dest="record_dir", help="Directory to record task execution logs.")
+    parser.add_argument("--mode", type=str, default="auto", help="Operational mode: 'auto' or 'manual'.")
+    parser.add_argument("--quiet", action="store_true", default=False, help="Run in quiet mode; minimal output.")
+    parser.add_argument("--max-subtask-chain-length", type=int, dest="max_subtask_chain_length",
+                        help="Maximum length of subtask chain.")
+    parser.add_argument("--enable-ask-human-for-help", action="store_true", dest="enable_ask_human_for_help",
+                        help="Flag to enable asking for human assistance.")
+    parser.add_argument("--max-plan-refine-chain-length", type=int, dest="max_plan_refine_chain_length",
+                        help="Maximum length of plan refinement chain.")
+    parser.add_argument("--max-plan-tree-depth", type=int, dest="max_plan_tree_depth",
+                        help="Maximum depth of the plan tree.")
+    parser.add_argument("--max-plan-tree-width", type=int, dest="max_plan_tree_width",
+                        help="Maximum width of the plan tree.")
+    parser.add_argument("--max-retry-times", type=int, dest="max_retry_times", help="Maximum number of retry attempts.")
+    parser.add_argument("--config-file", type=str, default=os.getenv('CONFIG_FILE', 'assets/config.yml'),
+                        dest="config_file", help="Path to the configuration file.")
 
-    parser.add_argument("--max_subtask_chain_length", type=int,)
-    parser.add_argument("--enable_ask_human_for_help", action="store_true",)
-    parser.add_argument("--max_plan_refine_chain_length", type=int,)
-    parser.add_argument("--max_plan_tree_depth", type=int,)
-    parser.add_argument("--max_plan_tree_width", type=int,)
-    parser.add_argument("--max_retry_times", type=int,)
-    parser.add_argument("--config_file",type=str,default=os.getenv('CONFIG_FILE', 'assets/config.yml'))
-
-    args = parser.parse_args()
-
-    return args
-
-
-if __name__ == '__main__':
-    
-    args = parse_args()
-    os.environ['CONFIG_FILE'] = args.config_file
-
-    quiet_mode = args.quiet
-    if quiet_mode:
-        original_stdout = sys.stdout
-        from XAgent.running_recorder import recorder
-        sys.stdout = open(os.path.join(recorder.record_root_dir,"command_line.ansi"),"w",encoding="utf-8")
+    return parser.parse_args()
 
 
-    args = vars(args)
+def execute_command_line_process(args: argparse.Namespace, quiet_mode: bool = False) -> None:
+    """
+    Execute the command line process based on the parsed arguments. If quiet mode is enabled,
+    redirect stdout to a file specified by the recorder's record_root_dir.
 
-    for key,value in args.items():
+    Args:
+        args (argparse.Namespace): Parsed command line arguments.
+        quiet_mode (bool): Whether to run in quiet mode, outputting to a file instead of the terminal.
+    """
+    args_dict = vars(args)
+    for key, value in args_dict.items():
         if value is not None:
             if key == 'model':
                 ARGS['default_completion_kwargs'] = deepcopy(CONFIG['default_completion_kwargs'])
                 ARGS['default_completion_kwargs']['model'] = value
             else:
                 ARGS[key] = value
+
+    # Redirect stdout to a file if quiet mode is true
+    if quiet_mode:
+        from XAgent.running_recorder import recorder
+        record_file_path = os.path.join(recorder.record_root_dir, "command_line.ansi")
+        with open(record_file_path, "w", encoding="utf-8") as file, redirect_stdout(file):
+            start_command_line(args_dict)
+    else:
+        start_command_line(args_dict)
+
+
+def start_command_line(args_dict: dict) -> None:
+    """
+    Start the command line interface with the provided arguments.
+
+    Args:
+        args_dict (dict): A dictionary of command line arguments.
+    """
     param = CommandLineParam(
-        task=args['task'],
-        upload_files=args['upload_files'],
+        task=args_dict['task'],
+        upload_files=args_dict.get('upload_files'),
         role="Assistant",
-        mode=args["mode"],
+        mode=args_dict["mode"],
     )
     cmd = CommandLine(param)
-
     cmd.start()
-    
-    if quiet_mode:
-        sys.stdout.close()
-        sys.stdout = original_stdout
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    os.environ['CONFIG_FILE'] = args.config_file
+
+    # The quiet_mode argument is passed directly to the function
+    execute_command_line_process(args, quiet_mode=args.quiet)


### PR DESCRIPTION
### 🤔 What is the nature of this change? / 这个变动的性质是？

- [ ] New feature / 新特性提交
- [ ] Fix bug / bug 修复
- [x] Refactor code or style / 重构代码或样式
- [ ] Performance optimization / 性能优化
- [ ] Build optimization / 构建优化
- [ ] Website, documentation, demo improvements / 网站、文档、Demo 改进
- [ ] Test related / 测试相关
- [ ] Other / 其他

### 🔗 Related Issue / 相关 Issue

close #261

### 💡 Background or solution / 需求背景和解决方案

- Moved the `quiet_mode` related code into a separate function to ensure it is only invoked when the `quiet_mode` flag is active.
- Added function annotations and docstrings for better code documentation and readability.
- Handled stdout redirection within the `execute_command_line_process` function to encapsulate the functionality.
- Streamlined the argument parsing by correctly using the `dest` parameter for argument names with hyphens.

Now command line accept `--record-dir` instead of `--record_dir`. But remains `record_dir` in parameter reading or setting.
