### PR TITLE
[Documentation] : Modify the "Run XAgent command" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We do not test or recommend using `gpt-3.5-turbo` to run XAgent due to minimal c
 
 - Run XAgent
 ```bash
-python run.py --task "put your task here" --config-file "assets/config.yml"
+python run.py --task "put your task here" --config_file "assets/config.yml"
 ```
 1. You can use the argument `--upload-files` to select the initial files you want to submit to XAgent.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -121,7 +121,7 @@ XAgent を実行するには、`gpt-4-32k` を使用することを強く推奨�
 
 - XAgent の実行
 ```bash
-python run.py --task "put your task here" --config-file "assets/config.yml"
+python run.py --task "put your task here" --config_file "assets/config.yml"
 ```
 1. 引数 `--upload-files` を使って、XAgent に送信したい初期ファイルを選択することができます。
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -123,7 +123,7 @@ pip install -r requirements.txt
 
 - 运行XAgent
 ```bash
-python run.py --task "put your task here" --config-file "assets/config.yml"
+python run.py --task "put your task here" --config_file "assets/config.yml"
 ```
 您可以使用参数`--upload-files`来指定提交给XAgent的文件。
 您的XAgent的本地工作空间在`local_workspace`中，您可以在运行过程中找到XAgent生成的所有文件。


### PR DESCRIPTION
The "Run XAgent command" in README.md is [ python run.py --task "put your task here" --config-file "assets/config.yml" ]
The correct command should be [ python run.py --task "put your task here" --config_file "assets/config.yml" ]