### PR TITLE
fix(docker-compose): ensure mysql starts before xagent-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./
       dockerfile: dockerfiles/ToolServerManager/Dockerfile
     ports:
-      - 8080:8080
+      - "8080:8080"
     volumes:
       - toolserverconfig:/app/assets/config
       - /var/run/docker.sock:/var/run/docker.sock
@@ -40,6 +40,35 @@ services:
     logging:
       driver: "none"
 
+  xagent-mysql:
+    image: mysql
+    command:
+      - --default-authentication-plugin=caching_sha2_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: xagent
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./XAgentServer/database/sql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysql -h localhost -u root -pxagent -e 'SELECT 1'"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  xagent-redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass xagent
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      
   XAgentServer:
     image: xagentteam/xagent-server:latest
     build:
@@ -63,39 +92,8 @@ services:
       xagent-redis:
         condition: service_healthy
 
-  xagent-mysql:
-    image: mysql
-    command:
-      - --default-authentication-plugin=caching_sha2_password
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-    environment:
-      MYSQL_ROOT_PASSWORD: xagent
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./XAgentServer/database/sql:/docker-entrypoint-initdb.d
-    healthcheck:
-      test: [ "CMD", "mysqladmin","ping", "-h", "localhost" ]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-
-  xagent-redis:
-    image: redis
-    ports:
-      - "6379:6379"
-    command: redis-server --requirepass xagent
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-
-
-
 volumes:
-  xagentmongodb:
+  xagentmongodb:  
   toolserverconfig:
     name: toolserverconfig
     driver: local


### PR DESCRIPTION
### 🤔 What is the nature of this change? / 这个变动的性质是？

- [ ] New feature / 新特性提交
- [x] Fix bug / bug 修复
- [ ] Refactor code or style / 重构代码或样式
- [ ] Performance optimization / 性能优化
- [x] Build optimization / 构建优化
- [ ] Website, documentation, demo improvements / 网站、文档、Demo 改进
- [ ] Test related / 测试相关
- [ ] Other / 其他

### 🔗 Related Issue / 相关 Issue

fix #257.

### 💡 Background or solution / 需求背景和解决方案

After checking the logs, it was found that `XAgent-Server` attempted to connect to the dependent `MySQL` container before it was ready, resulting in the ORM throwing a connection error. 
The currently used `mysqladmin ping` returned a `0` status code for `Access denied` without a password, leading Docker to consider the container as healthy. 
However, based on [discussion here](https://serverfault.com/questions/32459/monitoring-what-does-mysqladmin-ping-report), this approach was deemed unreliable, leading to the current error. 
Therefore, I first replaced the health check command with`mysql -e 'SELECT 1` and then prioritized the initialization sequence of the database container to ensure the connection was ready. 
After testing, the problem was resolved. The modified version also increased the startup time, taking about one minute to start the environment in my environment.

[docker compose log.txt](https://github.com/OpenBMB/XAgent/files/13539162/docker.compose.log.txt)


### 📝 Changelog / 更新日志

- Adjusted the startup sequence in `docker-compose.yml` to prioritize the launch of Redis and MySQL services ahead of xagent-server.
- Enhanced the health check for MySQL service by implementing a more specific method to ensure the database is fully operational before other services start.
