### PR TITLE
Check if object is already a DICT before it is passed to JSON5.loads for parsing

### DIFF
--- a/XAgent/agent/base_agent.py
+++ b/XAgent/agent/base_agent.py
@@ -126,7 +126,9 @@ class BaseAgent(metaclass=abc.ABCMeta):
                     *args,**kwargs)
                 
                 message = {}
-                function_call_args:dict = json5.loads(response["choices"][0]["message"]["function_call"]['arguments'])
+                function_call_args:dict = response["choices"][0]["message"]["function_call"]['arguments']
+                if isinstance(function_call_args, (str, bytes)):
+                    function_call_args = json5.loads(function_call_args)
                 
                 if arguments is not None:
                     message['arguments'] = {

--- a/XAgent/ai_functions/function_manager.py
+++ b/XAgent/ai_functions/function_manager.py
@@ -115,7 +115,9 @@ class FunctionManager:
                     function_call={'name':function_cfg['function']['name']},
                     **completions_kwargs
                 )
-                returns = json5.loads(response['choices'][0]['message']['function_call']['arguments'])
+                returns = response['choices'][0]['message']['function_call']['arguments']
+                if isinstance(returns, (str, bytes)):
+                    returns = json5.loads(returns)
             case 'xagent':
                 arguments = function_cfg['function']['parameters']
                 response = objgenerator.chatcompletion(

--- a/XAgent/ai_functions/request/openai.py
+++ b/XAgent/ai_functions/request/openai.py
@@ -1,5 +1,6 @@
 import json
 import openai
+import datetime as dt
 from XAgent.logs import logger
 from XAgent.config import CONFIG, get_apiconfig_by_model, get_model_name
 
@@ -59,6 +60,8 @@ if metadata.version("openai") < "1.0":
             api_base = chatcompletion_kwargs.pop("azure_endpoint", None)
             chatcompletion_kwargs.update({"api_base": api_base})
         chatcompletion_kwargs.update(kwargs)
+
+        print(f"[{dt.datetime.now()}] chatcompletion:", chatcompletion_kwargs)
 
         try:
             response = openai.ChatCompletion.create(**chatcompletion_kwargs)

--- a/XAgent/workflow/plan_exec.py
+++ b/XAgent/workflow/plan_exec.py
@@ -175,7 +175,11 @@ class PlanAgent():
             functions=[split_functions], 
         )
         
-        subtasks = json5.loads(new_message["function_call"]["arguments"])
+        subtasks = new_message["function_call"]["arguments"] 
+        
+        # To preserve the original flow in case `subtasks` is a string or bytes
+        if isinstance(subtasks, (str, bytes)):
+            subtasks = json5.loads(subtasks)
 
         for subtask_item in subtasks["subtasks"]:
             subplan = plan_function_output_parser(subtask_item)

--- a/XAgent/workflow/plan_exec.py
+++ b/XAgent/workflow/plan_exec.py
@@ -175,7 +175,11 @@ class PlanAgent():
             functions=[split_functions], 
         )
         
-        subtasks = json5.loads(new_message["function_call"]["arguments"])
+        subtasks = new_message["function_call"]["arguments"] 
+        
+        # To preserve the original flow in case `subtasks` is a string or bytes
+        if isinstance(subtasks, (str, bytes)):
+            subtasks = json5.loads(subtasks)
 
         for subtask_item in subtasks["subtasks"]:
             subplan = plan_function_output_parser(subtask_item)
@@ -270,7 +274,11 @@ class PlanAgent():
                 additional_insert_index=-1,
             )
             function_name = new_message["function_call"]["name"]
-            function_input = json5.loads(new_message["function_call"]["arguments"])
+            function_input = new_message["function_call"]["arguments"]
+
+            if isinstance(function_input, (str, bytes)):
+                function_input = json5.loads(function_input)
+
 
             if function_input['operation'] == 'split':
                 # modify function_input here

--- a/XAgent/workflow/reflection.py
+++ b/XAgent/workflow/reflection.py
@@ -57,6 +57,10 @@ def get_posterior_knowledge(all_plan: Plan,
         arguments=function_manager.get_function_schema('generate_posterior_knowledge')['parameters']
     )
 
-    data = json5.loads(new_message["arguments"])
+    data = new_message["arguments"]
+    
+    # To preserve the original flow in case `data` is a string or bytes
+    if isinstance(data, (str, bytes)):
+        data = json5.loads(data)
 
     return data


### PR DESCRIPTION
<!-- 
First of all, thank you for your contribution! 😄
首先，感谢你的贡献！😄
-->

### 🤔 What is the nature of this change? / 这个变动的性质是？

- [ ] New feature / 新特性提交
- [x] Fix bug / bug 修复
- [ ] Refactor code or style / 重构代码或样式
- [ ] Performance optimization / 性能优化
- [ ] Build optimization / 构建优化
- [ ] Website, documentation, demo improvements / 网站、文档、Demo 改进
- [ ] Test related / 测试相关
- [ ] Other / 其他

### 🔗 Related Issue / 相关 Issue

https://github.com/OpenBMB/XAgent/issues/396

### 💡 Background or solution / 需求背景和解决方案

In many places when using JSON5.loads to parse a serialized object, it doesnt check if the argument passed is a STR. The PR is to fix it by assuming the object is not serialized and only do `json5.loads` if it turns out to be a STRING.

### 📝 Changelog / 更新日志

Default behavior is preserved, no breaking changes/risks.
